### PR TITLE
Update DEVICE_PATH in device.mk

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-DEVICE_PATH := device/xiaomi/ruby
+DEVICE_PATH := device/xiaomi/rubyx
 
 # Installs gsi keys into ramdisk, to boot a developer GSI with verified boot.
 $(call inherit-product, $(SRC_TARGET_DIR)/product/developer_gsi_keys.mk)


### PR DESCRIPTION
Device path updated to reflect device/xiaomi/rubyx name instead of device/xiaomi/ruby to have consistent naming everywhere