### PR TITLE
rubyx: Set 120hz frame rate multiple threshold

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -196,6 +196,9 @@ WIFI_HAL_INTERFACE_COMBINATIONS += ,{{{STA}, 1}, {{NAN}, 1}}
 WIFI_HIDL_UNIFIED_SUPPLICANT_SERVICE_RC_ENTRY := true
 WIFI_FEATURE_HOSTAPD_11AX := true
 
+# Better Optimization flags
+BOARD_COMPILER_OPTIMIZATION := speed
+
 # Inherit the proprietary files
 -include device/xiaomi/miuicamera-rubyx/BoardConfig.mk
 include vendor/xiaomi/rubyx/BoardConfigVendor.mk

--- a/configs/props/vendor.prop
+++ b/configs/props/vendor.prop
@@ -82,6 +82,7 @@ debug.sf.early.sf.duration=27600000
 debug.sf.early.app.duration=20000000
 debug.sf.earlyGl.sf.duration=27600000
 debug.sf.earlyGl.app.duration=20000000
+debug.sf.frame_rate_multiple_threshold=120
 debug.sf.hwc.min.duration=23000000
 debug.sf.high_fps.late.sf.duration=13800000
 debug.sf.high_fps.late.app.duration=10000000


### PR DESCRIPTION
By setting 120hz frame rate multiple threshold, the system prioritizes running apps at frame rates that are clean multiples of 120Hz (e.g., 30, 60, or 120FPS), possibly overriding lower refresh rates. This setting might help improve motion smoothness and consistency, especially in games or UI animations.